### PR TITLE
change string ETH to Nuko

### DIFF
--- a/app/src/main/res/layout-land/fragment_detail_ov.xml
+++ b/app/src/main/res/layout-land/fragment_detail_ov.xml
@@ -80,7 +80,7 @@
                                 android:textColor="@color/colorPrimaryDark" />
 
                             <TextView
-                                android:text="ETH"
+                                android:text="Nuko"
                                 android:id="@+id/currency"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_detail_ov.xml
+++ b/app/src/main/res/layout/fragment_detail_ov.xml
@@ -82,7 +82,7 @@
                                 android:textColor="@color/colorPrimaryDark" />
 
                             <TextView
-                                android:text="ETH"
+                                android:text="Nuko"
                                 android:id="@+id/currency"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"


### PR DESCRIPTION
ウォレット起動時の文字列に間違いを発見したので修正しました。
なお命名(改変)規則を見つけられなかったので、マージ前に確認してください。